### PR TITLE
Install URMA for distributed communication (aarch64 only) on CANN 9.1.0-950 images

### DIFF
--- a/cann/9.1.0-950-openeuler24.03-py3.10/Dockerfile
+++ b/cann/9.1.0-950-openeuler24.03-py3.10/Dockerfile
@@ -162,6 +162,20 @@ RUN yum update -y && \
     && rm -rf /var/cache/yum \
     && rm -rf /tmp/*
 
+# Note: Install URMA (Unified RoCE Message Access) for distributed communication (aarch64 only)
+RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
+        yum install -y \
+            umdk-urma-lib \
+            umdk-urma-tools \
+            umdk-urma-bin \
+            ub-pkg-urma \
+            umdk-urma-devel \
+        && yum clean all \
+        && rm -rf /var/cache/yum; \
+    else \
+        echo "Non-arm64 platform, skipping URMA installation"; \
+    fi
+
 COPY --from=cann-installer /usr/local/python3.10.20 /usr/local/python3.10.20
 COPY --from=cann-installer /usr/local/Ascend /usr/local/Ascend
 COPY --from=cann-installer /etc/Ascend /etc/Ascend

--- a/cann/9.1.0-950-openeuler24.03-py3.11/Dockerfile
+++ b/cann/9.1.0-950-openeuler24.03-py3.11/Dockerfile
@@ -162,6 +162,20 @@ RUN yum update -y && \
     && rm -rf /var/cache/yum \
     && rm -rf /tmp/*
 
+# Note: Install URMA (Unified RoCE Message Access) for distributed communication (aarch64 only)
+RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
+        yum install -y \
+            umdk-urma-lib \
+            umdk-urma-tools \
+            umdk-urma-bin \
+            ub-pkg-urma \
+            umdk-urma-devel \
+        && yum clean all \
+        && rm -rf /var/cache/yum; \
+    else \
+        echo "Non-arm64 platform, skipping URMA installation"; \
+    fi
+
 COPY --from=cann-installer /usr/local/python3.11.15 /usr/local/python3.11.15
 COPY --from=cann-installer /usr/local/Ascend /usr/local/Ascend
 COPY --from=cann-installer /etc/Ascend /etc/Ascend

--- a/cann/9.1.0-950-openeuler24.03-py3.12/Dockerfile
+++ b/cann/9.1.0-950-openeuler24.03-py3.12/Dockerfile
@@ -162,6 +162,20 @@ RUN yum update -y && \
     && rm -rf /var/cache/yum \
     && rm -rf /tmp/*
 
+# Note: Install URMA (Unified RoCE Message Access) for distributed communication (aarch64 only)
+RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
+        yum install -y \
+            umdk-urma-lib \
+            umdk-urma-tools \
+            umdk-urma-bin \
+            ub-pkg-urma \
+            umdk-urma-devel \
+        && yum clean all \
+        && rm -rf /var/cache/yum; \
+    else \
+        echo "Non-arm64 platform, skipping URMA installation"; \
+    fi
+
 COPY --from=cann-installer /usr/local/python3.12.13 /usr/local/python3.12.13
 COPY --from=cann-installer /usr/local/Ascend /usr/local/Ascend
 COPY --from=cann-installer /etc/Ascend /etc/Ascend

--- a/cann/9.1.0-950-ubuntu22.04-py3.10/Dockerfile
+++ b/cann/9.1.0-950-ubuntu22.04-py3.10/Dockerfile
@@ -103,6 +103,8 @@ RUN . /usr/local/Ascend/ascend-toolkit/set_env.sh && \
 # Stage 3: Copy results from previous stages
 FROM ubuntu:22.04 AS official-ubuntu
 
+ARG TARGETPLATFORM
+
 # Python Environment variables
 ENV PATH=/usr/local/python3.10.20/bin:${PATH}
 ENV LD_LIBRARY_PATH=/usr/local/python3.10.20/lib:${LD_LIBRARY_PATH}
@@ -167,6 +169,22 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/tmp/* \
     && rm -rf /tmp/*
+
+# Note: Install URMA (Unified RoCE Message Access) for distributed communication (aarch64 only)
+RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
+        apt-get update && \
+        apt-get install -y --no-install-recommends libnl-3-dev libnl-genl-3-dev && \
+        wget --quiet https://mirrors.huaweicloud.com/ascend/archive/deb/unifiedbus/common/umdk-urma-26.06.0-B016.glibc217.aarch64.deb.tar.gz -O /tmp/umdk-urma.tar.gz && \
+        mkdir /tmp/umdk_pkgs && \
+        tar -mzxf /tmp/umdk-urma.tar.gz -C /tmp/umdk_pkgs && \
+        dpkg -i /tmp/umdk_pkgs/*.deb && \
+        ldconfig && \
+        apt-get clean && \
+        rm -rf /var/lib/apt/lists/* && \
+        rm -rf /tmp/*; \
+    else \
+        echo "Non-arm64 platform, skipping URMA installation"; \
+    fi
 
 COPY --from=cann-installer /usr/local/python3.10.20 /usr/local/python3.10.20
 COPY --from=cann-installer /usr/local/Ascend /usr/local/Ascend

--- a/cann/9.1.0-950-ubuntu22.04-py3.11/Dockerfile
+++ b/cann/9.1.0-950-ubuntu22.04-py3.11/Dockerfile
@@ -103,6 +103,8 @@ RUN . /usr/local/Ascend/ascend-toolkit/set_env.sh && \
 # Stage 3: Copy results from previous stages
 FROM ubuntu:22.04 AS official-ubuntu
 
+ARG TARGETPLATFORM
+
 # Python Environment variables
 ENV PATH=/usr/local/python3.11.15/bin:${PATH}
 ENV LD_LIBRARY_PATH=/usr/local/python3.11.15/lib:${LD_LIBRARY_PATH}
@@ -167,6 +169,22 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/tmp/* \
     && rm -rf /tmp/*
+
+# Note: Install URMA (Unified RoCE Message Access) for distributed communication (aarch64 only)
+RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
+        apt-get update && \
+        apt-get install -y --no-install-recommends libnl-3-dev libnl-genl-3-dev && \
+        wget --quiet https://mirrors.huaweicloud.com/ascend/archive/deb/unifiedbus/common/umdk-urma-26.06.0-B016.glibc217.aarch64.deb.tar.gz -O /tmp/umdk-urma.tar.gz && \
+        mkdir /tmp/umdk_pkgs && \
+        tar -mzxf /tmp/umdk-urma.tar.gz -C /tmp/umdk_pkgs && \
+        dpkg -i /tmp/umdk_pkgs/*.deb && \
+        ldconfig && \
+        apt-get clean && \
+        rm -rf /var/lib/apt/lists/* && \
+        rm -rf /tmp/*; \
+    else \
+        echo "Non-arm64 platform, skipping URMA installation"; \
+    fi
 
 COPY --from=cann-installer /usr/local/python3.11.15 /usr/local/python3.11.15
 COPY --from=cann-installer /usr/local/Ascend /usr/local/Ascend

--- a/cann/9.1.0-950-ubuntu22.04-py3.12/Dockerfile
+++ b/cann/9.1.0-950-ubuntu22.04-py3.12/Dockerfile
@@ -103,6 +103,8 @@ RUN . /usr/local/Ascend/ascend-toolkit/set_env.sh && \
 # Stage 3: Copy results from previous stages
 FROM ubuntu:22.04 AS official-ubuntu
 
+ARG TARGETPLATFORM
+
 # Python Environment variables
 ENV PATH=/usr/local/python3.12.13/bin:${PATH}
 ENV LD_LIBRARY_PATH=/usr/local/python3.12.13/lib:${LD_LIBRARY_PATH}
@@ -167,6 +169,22 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/tmp/* \
     && rm -rf /tmp/*
+
+# Note: Install URMA (Unified RoCE Message Access) for distributed communication (aarch64 only)
+RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
+        apt-get update && \
+        apt-get install -y --no-install-recommends libnl-3-dev libnl-genl-3-dev && \
+        wget --quiet https://mirrors.huaweicloud.com/ascend/archive/deb/unifiedbus/common/umdk-urma-26.06.0-B016.glibc217.aarch64.deb.tar.gz -O /tmp/umdk-urma.tar.gz && \
+        mkdir /tmp/umdk_pkgs && \
+        tar -mzxf /tmp/umdk-urma.tar.gz -C /tmp/umdk_pkgs && \
+        dpkg -i /tmp/umdk_pkgs/*.deb && \
+        ldconfig && \
+        apt-get clean && \
+        rm -rf /var/lib/apt/lists/* && \
+        rm -rf /tmp/*; \
+    else \
+        echo "Non-arm64 platform, skipping URMA installation"; \
+    fi
 
 COPY --from=cann-installer /usr/local/python3.12.13 /usr/local/python3.12.13
 COPY --from=cann-installer /usr/local/Ascend /usr/local/Ascend


### PR DESCRIPTION
## What
Install the URMA (Unified RoCE Message Access) runtime dependency for the CANN `9.1.0-950` image family. CANN loads `liburma.so` at runtime, so it is required even for single-node usage; RoCE multi-NPU communication also depends on it. Installed only on `linux/arm64`; `linux/amd64` is skipped.

## Scope
- `cann/9.1.0-950-openeuler24.03-py3.10`
- `cann/9.1.0-950-openeuler24.03-py3.11`
- `cann/9.1.0-950-openeuler24.03-py3.12`
- `cann/9.1.0-950-ubuntu22.04-py3.10`
- `cann/9.1.0-950-ubuntu22.04-py3.11`
- `cann/9.1.0-950-ubuntu22.04-py3.12`

## Changes
A new `RUN` is added in **Stage 3** right after the main package install and before `COPY --from=cann-installer`. It is gated by `if [ "${TARGETPLATFORM}" = "linux/arm64" ]`; x86 takes the `else` branch and skips, keeping the image lean.

### openEuler 24.03
`yum install` the 5 urma packages:
umdk-urma-lib / umdk-urma-tools / umdk-urma-bin / ub-pkg-urma / umdk-urma-devel

### Ubuntu 22.04
- Add `ARG TARGETPLATFORM` to Stage 3 (previously missing).
- First install `libnl-3-dev libnl-genl-3-dev` (urma dependencies).
- Download the deb tarball from the Huawei Cloud mirror:
  `https://mirrors.huaweicloud.com/ascend/archive/deb/unifiedbus/common/umdk-urma-26.06.0-B016.glibc217.aarch64.deb.tar.gz`
- `tar -mzxf` extract into `/tmp/umdk_pkgs` → `dpkg -i *.deb` → `ldconfig`.

