### PR TITLE
Modify default container startup command for CANN 950 ARM image

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -111,6 +111,7 @@ docker run \
     --device /dev/hisi_hdc \
     --device /dev/ummu \
     --device /dev/uburma \
+    -v /dev/log:/dev/log \
     -v /usr/local/dcmi:/usr/local/dcmi \
     -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
     -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \

--- a/OVERVIEW.zh.md
+++ b/OVERVIEW.zh.md
@@ -109,6 +109,7 @@ docker run \
     --device /dev/hisi_hdc \
     --device /dev/ummu \
     --device /dev/uburma \
+    -v /dev/log:/dev/log \
     -v /usr/local/dcmi:/usr/local/dcmi \
     -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
     -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \

--- a/cann_publish_version.json
+++ b/cann_publish_version.json
@@ -1,15 +1,39 @@
 {
   "versions": [
     {
+      "path": "cann/9.1.0-310p-ubuntu22.04-py3.10",
+      "tags": [
+        "9.1.0-310p-ubuntu22.04-py3.10"
+      ]
+    },
+    {
       "path": "cann/9.1.0-310p-ubuntu22.04-py3.11",
       "tags": [
         "9.1.0-310p-ubuntu22.04-py3.11"
       ]
     },
     {
+      "path": "cann/9.1.0-310p-ubuntu22.04-py3.12",
+      "tags": [
+        "9.1.0-310p-ubuntu22.04-py3.12"
+      ]
+    },
+    {
+      "path": "cann/9.1.0-310p-openeuler24.03-py3.10",
+      "tags": [
+        "9.1.0-310p-openeuler24.03-py3.10"
+      ]
+    },
+    {
       "path": "cann/9.1.0-310p-openeuler24.03-py3.11",
       "tags": [
         "9.1.0-310p-openeuler24.03-py3.11"
+      ]
+    },
+    {
+      "path": "cann/9.1.0-310p-openeuler24.03-py3.12",
+      "tags": [
+        "9.1.0-310p-openeuler24.03-py3.12"
       ]
     },
     {
@@ -25,6 +49,12 @@
       ]
     },
     {
+      "path": "cann/9.1.0-910-ubuntu22.04-py3.12",
+      "tags": [
+        "9.1.0-910-ubuntu22.04-py3.12"
+      ]
+    },
+    {
       "path": "cann/9.1.0-910-openeuler24.03-py3.10",
       "tags": [
         "9.1.0-910-openeuler24.03-py3.10"
@@ -34,6 +64,12 @@
       "path": "cann/9.1.0-910-openeuler24.03-py3.11",
       "tags": [
         "9.1.0-910-openeuler24.03-py3.11"
+      ]
+    },
+    {
+      "path": "cann/9.1.0-910-openeuler24.03-py3.12",
+      "tags": [
+        "9.1.0-910-openeuler24.03-py3.12"
       ]
     },
     {
@@ -49,6 +85,12 @@
       ]
     },
     {
+      "path": "cann/9.1.0-910b-ubuntu22.04-py3.12",
+      "tags": [
+        "9.1.0-910b-ubuntu22.04-py3.12"
+      ]
+    },
+    {
       "path": "cann/9.1.0-910b-openeuler24.03-py3.10",
       "tags": [
         "9.1.0-910b-openeuler24.03-py3.10"
@@ -58,6 +100,12 @@
       "path": "cann/9.1.0-910b-openeuler24.03-py3.11",
       "tags": [
         "9.1.0-910b-openeuler24.03-py3.11"
+      ]
+    },
+    {
+      "path": "cann/9.1.0-910b-openeuler24.03-py3.12",
+      "tags": [
+        "9.1.0-910b-openeuler24.03-py3.12"
       ]
     },
     {
@@ -73,6 +121,12 @@
       ]
     },
     {
+      "path": "cann/9.1.0-a3-ubuntu22.04-py3.12",
+      "tags": [
+        "9.1.0-a3-ubuntu22.04-py3.12"
+      ]
+    },
+    {
       "path": "cann/9.1.0-a3-openeuler24.03-py3.10",
       "tags": [
         "9.1.0-a3-openeuler24.03-py3.10"
@@ -82,6 +136,12 @@
       "path": "cann/9.1.0-a3-openeuler24.03-py3.11",
       "tags": [
         "9.1.0-a3-openeuler24.03-py3.11"
+      ]
+    },
+    {
+      "path": "cann/9.1.0-a3-openeuler24.03-py3.12",
+      "tags": [
+        "9.1.0-a3-openeuler24.03-py3.12"
       ]
     },
     {
@@ -97,6 +157,12 @@
       ]
     },
     {
+      "path": "cann/9.1.0-950-ubuntu22.04-py3.12",
+      "tags": [
+        "9.1.0-950-ubuntu22.04-py3.12"
+      ]
+    },
+    {
       "path": "cann/9.1.0-950-openeuler24.03-py3.10",
       "tags": [
         "9.1.0-950-openeuler24.03-py3.10"
@@ -106,6 +172,12 @@
       "path": "cann/9.1.0-950-openeuler24.03-py3.11",
       "tags": [
         "9.1.0-950-openeuler24.03-py3.11"
+      ]
+    },
+    {
+      "path": "cann/9.1.0-950-openeuler24.03-py3.12",
+      "tags": [
+        "9.1.0-950-openeuler24.03-py3.12"
       ]
     },
     {


### PR DESCRIPTION
add `-v /dev/log:/dev/log \` in startup command for `umdk` log not printing in the screem.