### PR TITLE
Fix CANN arm 950 Image 

### DIFF
--- a/cann/9.1.0-950-openeuler24.03-py3.10/Dockerfile
+++ b/cann/9.1.0-950-openeuler24.03-py3.10/Dockerfile
@@ -165,6 +165,7 @@ RUN yum update -y && \
 # Note: Install URMA (Unified RoCE Message Access) for distributed communication (aarch64 only)
 RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
         yum install -y \
+            rsyslog \
             umdk-urma-lib \
             umdk-urma-tools \
             umdk-urma-bin \
@@ -174,6 +175,24 @@ RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
         && rm -rf /var/cache/yum; \
     else \
         echo "Non-arm64 platform, skipping URMA installation"; \
+    fi
+
+RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
+        mkdir -p /var/log/umdk && \
+        printf '%s\n' \
+            'module(load="imuxsock" SysSock.Name="/dev/log")' \
+            '$FileCreateMode 0644' \
+            '$DirCreateMode 0755' \
+            ':msg, contains, "[liburma]"  -/var/log/umdk/urma.log' \
+            '& stop' \
+            ':msg, contains, "[libuvs]"   -/var/log/umdk/uvs.log' \
+            '& stop' \
+            ':msg, contains, "[URPC_LOG"  -/var/log/umdk/urpc.log' \
+            '& stop' \
+            ':msg, contains, "[UMQ"       -/var/log/umdk/umq.log' \
+            '& stop' \
+            '*.*                          -/var/log/umdk/umdk.log' \
+            '' > /etc/rsyslog.conf; \
     fi
 
 COPY --from=cann-installer /usr/local/python3.10.20 /usr/local/python3.10.20
@@ -202,4 +221,5 @@ ENTRYPOINT ["/bin/bash", "-c", "\
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/cann-9.1.0/share/info/ascendnpu-ir/bin/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh --cxx_abi=${ATB_CXX_ABI:-1} && \
+    if [ -x /usr/sbin/rsyslogd ]; then nohup /usr/sbin/rsyslogd >/dev/null 2>&1 & for i in $(seq 1 50); do [ -S /dev/log ] && break; sleep 0.1; done; fi; \
     exec \"$@\"", "--"]

--- a/cann/9.1.0-950-openeuler24.03-py3.11/Dockerfile
+++ b/cann/9.1.0-950-openeuler24.03-py3.11/Dockerfile
@@ -165,6 +165,7 @@ RUN yum update -y && \
 # Note: Install URMA (Unified RoCE Message Access) for distributed communication (aarch64 only)
 RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
         yum install -y \
+            rsyslog \
             umdk-urma-lib \
             umdk-urma-tools \
             umdk-urma-bin \
@@ -174,6 +175,24 @@ RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
         && rm -rf /var/cache/yum; \
     else \
         echo "Non-arm64 platform, skipping URMA installation"; \
+    fi
+
+RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
+        mkdir -p /var/log/umdk && \
+        printf '%s\n' \
+            'module(load="imuxsock" SysSock.Name="/dev/log")' \
+            '$FileCreateMode 0644' \
+            '$DirCreateMode 0755' \
+            ':msg, contains, "[liburma]"  -/var/log/umdk/urma.log' \
+            '& stop' \
+            ':msg, contains, "[libuvs]"   -/var/log/umdk/uvs.log' \
+            '& stop' \
+            ':msg, contains, "[URPC_LOG"  -/var/log/umdk/urpc.log' \
+            '& stop' \
+            ':msg, contains, "[UMQ"       -/var/log/umdk/umq.log' \
+            '& stop' \
+            '*.*                          -/var/log/umdk/umdk.log' \
+            '' > /etc/rsyslog.conf; \
     fi
 
 COPY --from=cann-installer /usr/local/python3.11.15 /usr/local/python3.11.15
@@ -202,4 +221,5 @@ ENTRYPOINT ["/bin/bash", "-c", "\
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/cann-9.1.0/share/info/ascendnpu-ir/bin/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh --cxx_abi=${ATB_CXX_ABI:-1} && \
+    if [ -x /usr/sbin/rsyslogd ]; then nohup /usr/sbin/rsyslogd >/dev/null 2>&1 & for i in $(seq 1 50); do [ -S /dev/log ] && break; sleep 0.1; done; fi; \
     exec \"$@\"", "--"]

--- a/cann/9.1.0-950-openeuler24.03-py3.12/Dockerfile
+++ b/cann/9.1.0-950-openeuler24.03-py3.12/Dockerfile
@@ -165,6 +165,7 @@ RUN yum update -y && \
 # Note: Install URMA (Unified RoCE Message Access) for distributed communication (aarch64 only)
 RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
         yum install -y \
+            rsyslog \
             umdk-urma-lib \
             umdk-urma-tools \
             umdk-urma-bin \
@@ -174,6 +175,24 @@ RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
         && rm -rf /var/cache/yum; \
     else \
         echo "Non-arm64 platform, skipping URMA installation"; \
+    fi
+
+RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
+        mkdir -p /var/log/umdk && \
+        printf '%s\n' \
+            'module(load="imuxsock" SysSock.Name="/dev/log")' \
+            '$FileCreateMode 0644' \
+            '$DirCreateMode 0755' \
+            ':msg, contains, "[liburma]"  -/var/log/umdk/urma.log' \
+            '& stop' \
+            ':msg, contains, "[libuvs]"   -/var/log/umdk/uvs.log' \
+            '& stop' \
+            ':msg, contains, "[URPC_LOG"  -/var/log/umdk/urpc.log' \
+            '& stop' \
+            ':msg, contains, "[UMQ"       -/var/log/umdk/umq.log' \
+            '& stop' \
+            '*.*                          -/var/log/umdk/umdk.log' \
+            '' > /etc/rsyslog.conf; \
     fi
 
 COPY --from=cann-installer /usr/local/python3.12.13 /usr/local/python3.12.13
@@ -202,4 +221,5 @@ ENTRYPOINT ["/bin/bash", "-c", "\
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/cann-9.1.0/share/info/ascendnpu-ir/bin/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh --cxx_abi=${ATB_CXX_ABI:-1} && \
+    if [ -x /usr/sbin/rsyslogd ]; then nohup /usr/sbin/rsyslogd >/dev/null 2>&1 & for i in $(seq 1 50); do [ -S /dev/log ] && break; sleep 0.1; done; fi; \
     exec \"$@\"", "--"]

--- a/cann/9.1.0-950-ubuntu22.04-py3.10/Dockerfile
+++ b/cann/9.1.0-950-ubuntu22.04-py3.10/Dockerfile
@@ -173,7 +173,7 @@ RUN apt-get update \
 # Note: Install URMA (Unified RoCE Message Access) for distributed communication (aarch64 only)
 RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
         apt-get update && \
-        apt-get install -y --no-install-recommends libnl-3-dev libnl-genl-3-dev && \
+        apt-get install -y --no-install-recommends libnl-3-dev libnl-genl-3-dev rsyslog && \
         wget --quiet https://mirrors.huaweicloud.com/ascend/archive/deb/unifiedbus/common/umdk-urma-26.06.0-B016.glibc217.aarch64.deb.tar.gz -O /tmp/umdk-urma.tar.gz && \
         mkdir /tmp/umdk_pkgs && \
         tar -mzxf /tmp/umdk-urma.tar.gz -C /tmp/umdk_pkgs && \
@@ -184,6 +184,24 @@ RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
         rm -rf /tmp/*; \
     else \
         echo "Non-arm64 platform, skipping URMA installation"; \
+    fi
+
+RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
+        mkdir -p /var/log/umdk && \
+        printf '%s\n' \
+            'module(load="imuxsock" SysSock.Name="/dev/log")' \
+            '$FileCreateMode 0644' \
+            '$DirCreateMode 0755' \
+            ':msg, contains, "[liburma]"  -/var/log/umdk/urma.log' \
+            '& stop' \
+            ':msg, contains, "[libuvs]"   -/var/log/umdk/uvs.log' \
+            '& stop' \
+            ':msg, contains, "[URPC_LOG"  -/var/log/umdk/urpc.log' \
+            '& stop' \
+            ':msg, contains, "[UMQ"       -/var/log/umdk/umq.log' \
+            '& stop' \
+            '*.*                          -/var/log/umdk/umdk.log' \
+            '' > /etc/rsyslog.conf; \
     fi
 
 COPY --from=cann-installer /usr/local/python3.10.20 /usr/local/python3.10.20
@@ -206,4 +224,5 @@ ENTRYPOINT ["/bin/bash", "-c", "\
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/cann-9.1.0/share/info/ascendnpu-ir/bin/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh --cxx_abi=${ATB_CXX_ABI:-1}&& \
+    if [ -x /usr/sbin/rsyslogd ]; then nohup /usr/sbin/rsyslogd >/dev/null 2>&1 & for i in $(seq 1 50); do [ -S /dev/log ] && break; sleep 0.1; done; fi; \
     exec \"$@\"", "--"]

--- a/cann/9.1.0-950-ubuntu22.04-py3.11/Dockerfile
+++ b/cann/9.1.0-950-ubuntu22.04-py3.11/Dockerfile
@@ -173,7 +173,7 @@ RUN apt-get update \
 # Note: Install URMA (Unified RoCE Message Access) for distributed communication (aarch64 only)
 RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
         apt-get update && \
-        apt-get install -y --no-install-recommends libnl-3-dev libnl-genl-3-dev && \
+        apt-get install -y --no-install-recommends libnl-3-dev libnl-genl-3-dev rsyslog && \
         wget --quiet https://mirrors.huaweicloud.com/ascend/archive/deb/unifiedbus/common/umdk-urma-26.06.0-B016.glibc217.aarch64.deb.tar.gz -O /tmp/umdk-urma.tar.gz && \
         mkdir /tmp/umdk_pkgs && \
         tar -mzxf /tmp/umdk-urma.tar.gz -C /tmp/umdk_pkgs && \
@@ -184,6 +184,24 @@ RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
         rm -rf /tmp/*; \
     else \
         echo "Non-arm64 platform, skipping URMA installation"; \
+    fi
+
+RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
+        mkdir -p /var/log/umdk && \
+        printf '%s\n' \
+            'module(load="imuxsock" SysSock.Name="/dev/log")' \
+            '$FileCreateMode 0644' \
+            '$DirCreateMode 0755' \
+            ':msg, contains, "[liburma]"  -/var/log/umdk/urma.log' \
+            '& stop' \
+            ':msg, contains, "[libuvs]"   -/var/log/umdk/uvs.log' \
+            '& stop' \
+            ':msg, contains, "[URPC_LOG"  -/var/log/umdk/urpc.log' \
+            '& stop' \
+            ':msg, contains, "[UMQ"       -/var/log/umdk/umq.log' \
+            '& stop' \
+            '*.*                          -/var/log/umdk/umdk.log' \
+            '' > /etc/rsyslog.conf; \
     fi
 
 COPY --from=cann-installer /usr/local/python3.11.15 /usr/local/python3.11.15
@@ -206,4 +224,5 @@ ENTRYPOINT ["/bin/bash", "-c", "\
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/cann-9.1.0/share/info/ascendnpu-ir/bin/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh --cxx_abi=${ATB_CXX_ABI:-1}&& \
+    if [ -x /usr/sbin/rsyslogd ]; then nohup /usr/sbin/rsyslogd >/dev/null 2>&1 & for i in $(seq 1 50); do [ -S /dev/log ] && break; sleep 0.1; done; fi; \
     exec \"$@\"", "--"]

--- a/cann/9.1.0-950-ubuntu22.04-py3.12/Dockerfile
+++ b/cann/9.1.0-950-ubuntu22.04-py3.12/Dockerfile
@@ -173,7 +173,7 @@ RUN apt-get update \
 # Note: Install URMA (Unified RoCE Message Access) for distributed communication (aarch64 only)
 RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
         apt-get update && \
-        apt-get install -y --no-install-recommends libnl-3-dev libnl-genl-3-dev && \
+        apt-get install -y --no-install-recommends libnl-3-dev libnl-genl-3-dev rsyslog && \
         wget --quiet https://mirrors.huaweicloud.com/ascend/archive/deb/unifiedbus/common/umdk-urma-26.06.0-B016.glibc217.aarch64.deb.tar.gz -O /tmp/umdk-urma.tar.gz && \
         mkdir /tmp/umdk_pkgs && \
         tar -mzxf /tmp/umdk-urma.tar.gz -C /tmp/umdk_pkgs && \
@@ -184,6 +184,24 @@ RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
         rm -rf /tmp/*; \
     else \
         echo "Non-arm64 platform, skipping URMA installation"; \
+    fi
+
+RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
+        mkdir -p /var/log/umdk && \
+        printf '%s\n' \
+            'module(load="imuxsock" SysSock.Name="/dev/log")' \
+            '$FileCreateMode 0644' \
+            '$DirCreateMode 0755' \
+            ':msg, contains, "[liburma]"  -/var/log/umdk/urma.log' \
+            '& stop' \
+            ':msg, contains, "[libuvs]"   -/var/log/umdk/uvs.log' \
+            '& stop' \
+            ':msg, contains, "[URPC_LOG"  -/var/log/umdk/urpc.log' \
+            '& stop' \
+            ':msg, contains, "[UMQ"       -/var/log/umdk/umq.log' \
+            '& stop' \
+            '*.*                          -/var/log/umdk/umdk.log' \
+            '' > /etc/rsyslog.conf; \
     fi
 
 COPY --from=cann-installer /usr/local/python3.12.13 /usr/local/python3.12.13
@@ -206,4 +224,5 @@ ENTRYPOINT ["/bin/bash", "-c", "\
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/cann-9.1.0/share/info/ascendnpu-ir/bin/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh --cxx_abi=${ATB_CXX_ABI:-1}&& \
+    if [ -x /usr/sbin/rsyslogd ]; then nohup /usr/sbin/rsyslogd >/dev/null 2>&1 & for i in $(seq 1 50); do [ -S /dev/log ] && break; sleep 0.1; done; fi; \
     exec \"$@\"", "--"]

--- a/cann_publish_version.json
+++ b/cann_publish_version.json
@@ -7,6 +7,12 @@
     //   ]
     // },
     {
+      "path": "cann/9.1.0-310p-ubuntu22.04-py3.10",
+      "tags": [
+        "9.1.0-310p-ubuntu22.04-py3.10"
+      ]
+    },
+    {
       "path": "cann/9.1.0-310p-ubuntu22.04-py3.11",
       "tags": [
         "9.1.0-310p-ubuntu22.04-py3.11"
@@ -25,6 +31,18 @@
     //   ]
     // },
     {
+      "path": "cann/9.1.0-310p-ubuntu22.04-py3.12",
+      "tags": [
+        "9.1.0-310p-ubuntu22.04-py3.12"
+      ]
+    },
+    {
+      "path": "cann/9.1.0-310p-openeuler24.03-py3.10",
+      "tags": [
+        "9.1.0-310p-openeuler24.03-py3.10"
+      ]
+    },
+    {
       "path": "cann/9.1.0-310p-openeuler24.03-py3.11",
       "tags": [
         "9.1.0-310p-openeuler24.03-py3.11"
@@ -36,6 +54,12 @@
     //     "9.1.0-310p-openeuler24.03-py3.12"
     //   ]
     // },
+    {
+      "path": "cann/9.1.0-310p-openeuler24.03-py3.12",
+      "tags": [
+        "9.1.0-310p-openeuler24.03-py3.12"
+      ]
+    },
     {
       "path": "cann/9.1.0-910-ubuntu22.04-py3.10",
       "tags": [
@@ -55,6 +79,12 @@
     //   ]
     // },
     {
+      "path": "cann/9.1.0-910-ubuntu22.04-py3.12",
+      "tags": [
+        "9.1.0-910-ubuntu22.04-py3.12"
+      ]
+    },
+    {
       "path": "cann/9.1.0-910-openeuler24.03-py3.10",
       "tags": [
         "9.1.0-910-openeuler24.03-py3.10"
@@ -72,6 +102,12 @@
     //     "9.1.0-910-openeuler24.03-py3.12"
     //   ]
     // },
+    {
+      "path": "cann/9.1.0-910-openeuler24.03-py3.12",
+      "tags": [
+        "9.1.0-910-openeuler24.03-py3.12"
+      ]
+    },
     {
       "path": "cann/9.1.0-910b-ubuntu22.04-py3.10",
       "tags": [
@@ -91,6 +127,12 @@
     //   ]
     // },
     {
+      "path": "cann/9.1.0-910b-ubuntu22.04-py3.12",
+      "tags": [
+        "9.1.0-910b-ubuntu22.04-py3.12"
+      ]
+    },
+    {
       "path": "cann/9.1.0-910b-openeuler24.03-py3.10",
       "tags": [
         "9.1.0-910b-openeuler24.03-py3.10"
@@ -108,6 +150,12 @@
     //     "9.1.0-910b-openeuler24.03-py3.12"
     //   ]
     // },
+    {
+      "path": "cann/9.1.0-910b-openeuler24.03-py3.12",
+      "tags": [
+        "9.1.0-910b-openeuler24.03-py3.12"
+      ]
+    },
     {
       "path": "cann/9.1.0-a3-ubuntu22.04-py3.10",
       "tags": [
@@ -127,6 +175,12 @@
     //   ]
     // },
     {
+      "path": "cann/9.1.0-a3-ubuntu22.04-py3.12",
+      "tags": [
+        "9.1.0-a3-ubuntu22.04-py3.12"
+      ]
+    },
+    {
       "path": "cann/9.1.0-a3-openeuler24.03-py3.10",
       "tags": [
         "9.1.0-a3-openeuler24.03-py3.10"
@@ -144,6 +198,12 @@
     //     "9.1.0-a3-openeuler24.03-py3.12"
     //   ]
     // },
+    {
+      "path": "cann/9.1.0-a3-openeuler24.03-py3.12",
+      "tags": [
+        "9.1.0-a3-openeuler24.03-py3.12"
+      ]
+    },
     {
       "path": "cann/9.1.0-950-ubuntu22.04-py3.10",
       "tags": [
@@ -163,6 +223,12 @@
     //   ]
     // },
     {
+      "path": "cann/9.1.0-950-ubuntu22.04-py3.12",
+      "tags": [
+        "9.1.0-950-ubuntu22.04-py3.12"
+      ]
+    },
+    {
       "path": "cann/9.1.0-950-openeuler24.03-py3.10",
       "tags": [
         "9.1.0-950-openeuler24.03-py3.10"
@@ -180,6 +246,12 @@
     //     "9.1.0-950-openeuler24.03-py3.12"
     //   ]
     // },
+    {
+      "path": "cann/9.1.0-950-openeuler24.03-py3.12",
+      "tags": [
+        "9.1.0-950-openeuler24.03-py3.12"
+      ]
+    },
     {
       "path": "cann/9.0.1-310p-ubuntu22.04-py3.10",
       "tags": [

--- a/cann_publish_version.json
+++ b/cann_publish_version.json
@@ -1,11 +1,5 @@
 {
   "versions": [
-    // {
-    //   "path": "cann/9.1.0-310p-ubuntu22.04-py3.10",
-    //   "tags": [
-    //     "9.1.0-310p-ubuntu22.04-py3.10"
-    //   ]
-    // },
     {
       "path": "cann/9.1.0-310p-ubuntu22.04-py3.10",
       "tags": [
@@ -18,18 +12,6 @@
         "9.1.0-310p-ubuntu22.04-py3.11"
       ]
     },
-    // {
-    //   "path": "cann/9.1.0-310p-ubuntu22.04-py3.12",
-    //   "tags": [
-    //     "9.1.0-310p-ubuntu22.04-py3.12"
-    //   ]
-    // },
-    // {
-    //   "path": "cann/9.1.0-310p-openeuler24.03-py3.10",
-    //   "tags": [
-    //     "9.1.0-310p-openeuler24.03-py3.10"
-    //   ]
-    // },
     {
       "path": "cann/9.1.0-310p-ubuntu22.04-py3.12",
       "tags": [
@@ -48,12 +30,6 @@
         "9.1.0-310p-openeuler24.03-py3.11"
       ]
     },
-    // {
-    //   "path": "cann/9.1.0-310p-openeuler24.03-py3.12",
-    //   "tags": [
-    //     "9.1.0-310p-openeuler24.03-py3.12"
-    //   ]
-    // },
     {
       "path": "cann/9.1.0-310p-openeuler24.03-py3.12",
       "tags": [
@@ -72,12 +48,6 @@
         "9.1.0-910-ubuntu22.04-py3.11"
       ]
     },
-    // {
-    //   "path": "cann/9.1.0-910-ubuntu22.04-py3.12",
-    //   "tags": [
-    //     "9.1.0-910-ubuntu22.04-py3.12"
-    //   ]
-    // },
     {
       "path": "cann/9.1.0-910-ubuntu22.04-py3.12",
       "tags": [
@@ -96,12 +66,6 @@
         "9.1.0-910-openeuler24.03-py3.11"
       ]
     },
-    // {
-    //   "path": "cann/9.1.0-910-openeuler24.03-py3.12",
-    //   "tags": [
-    //     "9.1.0-910-openeuler24.03-py3.12"
-    //   ]
-    // },
     {
       "path": "cann/9.1.0-910-openeuler24.03-py3.12",
       "tags": [
@@ -120,12 +84,6 @@
         "9.1.0-910b-ubuntu22.04-py3.11"
       ]
     },
-    // {
-    //   "path": "cann/9.1.0-910b-ubuntu22.04-py3.12",
-    //   "tags": [
-    //     "9.1.0-910b-ubuntu22.04-py3.12"
-    //   ]
-    // },
     {
       "path": "cann/9.1.0-910b-ubuntu22.04-py3.12",
       "tags": [
@@ -144,12 +102,6 @@
         "9.1.0-910b-openeuler24.03-py3.11"
       ]
     },
-    // {
-    //   "path": "cann/9.1.0-910b-openeuler24.03-py3.12",
-    //   "tags": [
-    //     "9.1.0-910b-openeuler24.03-py3.12"
-    //   ]
-    // },
     {
       "path": "cann/9.1.0-910b-openeuler24.03-py3.12",
       "tags": [
@@ -168,12 +120,6 @@
         "9.1.0-a3-ubuntu22.04-py3.11"
       ]
     },
-    // {
-    //   "path": "cann/9.1.0-a3-ubuntu22.04-py3.12",
-    //   "tags": [
-    //     "9.1.0-a3-ubuntu22.04-py3.12"
-    //   ]
-    // },
     {
       "path": "cann/9.1.0-a3-ubuntu22.04-py3.12",
       "tags": [
@@ -192,12 +138,6 @@
         "9.1.0-a3-openeuler24.03-py3.11"
       ]
     },
-    // {
-    //   "path": "cann/9.1.0-a3-openeuler24.03-py3.12",
-    //   "tags": [
-    //     "9.1.0-a3-openeuler24.03-py3.12"
-    //   ]
-    // },
     {
       "path": "cann/9.1.0-a3-openeuler24.03-py3.12",
       "tags": [
@@ -216,12 +156,6 @@
         "9.1.0-950-ubuntu22.04-py3.11"
       ]
     },
-    // {
-    //   "path": "cann/9.1.0-950-ubuntu22.04-py3.12",
-    //   "tags": [
-    //     "9.1.0-950-ubuntu22.04-py3.12"
-    //   ]
-    // },
     {
       "path": "cann/9.1.0-950-ubuntu22.04-py3.12",
       "tags": [
@@ -240,12 +174,6 @@
         "9.1.0-950-openeuler24.03-py3.11"
       ]
     },
-    // {
-    //   "path": "cann/9.1.0-950-openeuler24.03-py3.12",
-    //   "tags": [
-    //     "9.1.0-950-openeuler24.03-py3.12"
-    //   ]
-    // },
     {
       "path": "cann/9.1.0-950-openeuler24.03-py3.12",
       "tags": [


### PR DESCRIPTION
Install `rsyslog` in the CANN 950 ARM image to resolve the issue of logs being printed to the console (screen).

Restore the JSON configuration that was previously removed for the batch publishing of the image.

In #117, URMA was introduced into the CANN 950 image to resolve the issue where the CANN image could not be used properly. The root cause is that URMA is required to adapt to UB communication.

Subsequently, a problem occurred where URMA logs were being printed to the console. This happens when running npu-smi info. This PR is intended to fix that console log spamming issue